### PR TITLE
Added .toUpperCase() to areas where comparing nodeName == "OBJECT" for XHTML compatibility 

### DIFF
--- a/swfobject/src/swfobject.js
+++ b/swfobject/src/swfobject.js
@@ -299,7 +299,7 @@ var swfobject = function() {
         var r = null,
             o = getElementById(objectIdStr);
 
-        if (o && o.nodeName === "OBJECT") {
+        if (o && o.nodeName.toUpperCase() === "OBJECT") {
 
             //If targeted object is valid Flash file
             if (typeof o.SetVariable !== UNDEF){
@@ -349,7 +349,7 @@ var swfobject = function() {
         storedCallbackObj = {success:false, id:replaceElemIdStr};
 
         if (obj) {
-            if (obj.nodeName == "OBJECT") { // static publishing
+            if (obj.nodeName.toUpperCase() == "OBJECT") { // static publishing
                 storedFbContent = abstractFbContent(obj);
                 storedFbContentId = null;
             }
@@ -508,7 +508,7 @@ var swfobject = function() {
     */
     function removeSWF(id) {
         var obj = getElementById(id);
-        if (obj && obj.nodeName == "OBJECT") {
+        if (obj && obj.nodeName.toUpperCase() == "OBJECT") {
             if (ua.ie) {
                 obj.style.display = "none";
                 (function removeSWFInIE(){


### PR DESCRIPTION
I'd like to help support swfObject to be 100% xhtml compatible.  We use application/xhtml+xml on our websites at work and we've been using swfObject for years without any issues (until IE9, of course..)

With IE 9 actually supporting xhtml, we've starting to run into a couple issues.  I submitted a bug last week here: http://code.google.com/p/swfobject/issues/detail?id=613 but it was marked invalid.

This patch I'm submitting will fix the issue I reported in bug 613.

You can see where we are using swf object in XHTML on any of Blizzard's Battle.net sites, e.g. http://us.battle.net/wow/en/media/videos/?view#/hour-of-twilight
