### PR TITLE
AMD module support

### DIFF
--- a/swfobject/src/swfobject.js
+++ b/swfobject/src/swfobject.js
@@ -1,6 +1,7 @@
 /*!    SWFObject v2.3.20120118 <http://github.com/swfobject/swfobject>
     is released under the MIT License <http://www.opensource.org/licenses/mit-license.php>
 */
+(function (global) {
 
 var swfobject = function() {
 
@@ -834,4 +835,22 @@ var swfobject = function() {
 		version: "2.3"
 
     };
-}();
+};
+
+// Check if in an AMD environment
+if (typeof define === "function" && define.amd) {
+    // Check if in a windowed AMD environment
+    if (global.window) {
+    	define("swfobject", [], function () {
+       	    return swfobject();
+   	});	
+    } else {
+    	// Not in a windowed AMD environment, return null so developer can mock this dep
+    	return null;
+    }
+} else { // Assign swfobject to global scope 
+    global['swfobject'] = swfobject();
+}
+
+})(this);
+


### PR DESCRIPTION
Wrapped the swfobject var in a self-executing function that checks if the code is running in an AMD environment, and if so wraps swfobject in a define() call, otherwise assigns it to the global scope as usual. Also makes sure swfobject is in a windowed environment before initializing swfobject, lets developers inject a mocked version of the dependency if a window object isn't present.
