### PR TITLE
Add a bower.json with a valid semver version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,5 @@
+{
+  "name": "swfobject",
+  "version": "2.2.0",
+  "main": "./swfobject/swfobject.js"
+}


### PR DESCRIPTION
We have tooling that fails because swfobject has no bower.json file. This PR creates the file and adds the usual three-part semver version. If you're happy to merge this it'll just need you to add a tag `v2.2.0` after merge.
