### PR TITLE
fix error message on IE in onunload Event

### DIFF
--- a/swfobject/src/swfobject.js
+++ b/swfobject/src/swfobject.js
@@ -634,10 +634,14 @@ var swfobject = function () {
                     ua[k] = null;
                 }
                 ua = null;
-                for (var l in swfobject) {
-                    swfobject[l] = null;
+
+                if (window.swfobject)
+                {
+                    for (var l in swfobject) {
+                        swfobject[l] = null;
+                    }
+                    swfobject = null;
                 }
-                swfobject = null;
             });
         }
     }();


### PR DESCRIPTION
there is no global swfobject var at window in my amd case.
the fixes the occurirng error, so merge it please.