### PR TITLE
Set `name` as well as `id`

### DIFF
--- a/swfobject/src/swfobject.js
+++ b/swfobject/src/swfobject.js
@@ -434,6 +434,10 @@ var swfobject = function () {
                 attrLower,
                 param;
 
+            if (typeof o.name === UNDEF) {
+                o.setAttribute("name", id);
+            }
+
             if (typeof attObj.id === UNDEF) { // if no 'id' is defined for the object element, it will inherit the 'id' from the fallback content
                 attObj.id = id;
             }


### PR DESCRIPTION
Set `name` as well as `id` so Firefox PPAPI can find flash element when using ExternalApi from flash
